### PR TITLE
bug fix for #15 implementing a different calling method with the S3 API

### DIFF
--- a/keychain/app.py
+++ b/keychain/app.py
@@ -7,7 +7,7 @@ import eventlet
 import requests
 import boto
 import boto.s3.key
-from boto.s3.connection import OrdinaryCallingFormat, Location
+from boto.s3.connection import OrdinaryCallingFormat
 
 from flask import Flask
 from flask import request
@@ -18,7 +18,6 @@ app = Flask('keychain')
 app.config['DEBUG'] = True
 
 bucket_name = os.environ.get('KEYCHAIN_BUCKET_NAME')
-bucket_location = os.environ.get('KEYCHAIN_BUCKET_LOCATION', Location.DEFAULT)
 action_expiry = 3600
 pending_actions = {}
 
@@ -29,7 +28,7 @@ def s3key(email, name):
     if not s3:
         s3 = boto.connect_s3(calling_format=OrdinaryCallingFormat())
     k = boto.s3.key.Key(
-        s3.create_bucket(bucket_name, location=bucket_location))
+        s3.get_bucket(bucket_name))
     k.key = '{}.{}'.format(email, name)
     return k
 
@@ -37,7 +36,7 @@ def s3keys(email):
     global s3
     if not s3:
         s3 = boto.connect_s3(calling_format=OrdinaryCallingFormat())
-    b = s3.create_bucket(bucket_name, location=bucket_location)
+    b = s3.get_bucket(bucket_name)
     return b.list(prefix=email)
 
 def lookup_key(email, name=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask==0.9
 requests==0.14.1
-boto==2.6.0
+boto==2.34.0
 eventlet==0.9.17


### PR DESCRIPTION
On close inspection, I was able to track down the problem. With the new S3 API, you are likely to have problems connecting via HTTPS to your buckets if your bucket names have periods (.) in them. In order to fix this, I changed from using the default calling format of "SubdomainCallingFormat" to using the "OrdinaryCallingFormat"[1](https://github.com/boto/boto/issues/421). This also has the side effect of creating/using buckets in the US region by default. In order to compensate, I've added a new environment parameter called the KEYCHAIN_BUCKET_LOCATION which will contain the region that your bucket is/should be located.